### PR TITLE
queuefeed: create partition cache

### DIFF
--- a/pkg/sql/queuefeed/BUILD.bazel
+++ b/pkg/sql/queuefeed/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "assignments.go",
         "manager.go",
+        "partition_cache.go",
         "partitions.go",
         "reader.go",
     ],
@@ -42,6 +43,7 @@ go_test(
         "assignments_test.go",
         "main_test.go",
         "manager_test.go",
+        "partition_cache_test.go",
         "partitions_test.go",
         "smoke_test.go",
     ],

--- a/pkg/sql/queuefeed/partition_cache.go
+++ b/pkg/sql/queuefeed/partition_cache.go
@@ -1,0 +1,275 @@
+package queuefeed
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+)
+
+type partitionCache struct {
+	// partitions is a stale cache of the current state of the partition's
+	// table. Any assignment decisions and updates should be made using
+	// transactions.
+	partitions map[int64]Partition
+
+	// assignmentIndex is a map of sessions to assigned partitions.
+	assignmentIndex map[Session]map[int64]struct{}
+
+	sessions map[Session]struct{}
+}
+
+func (p *partitionCache) DebugString() string {
+	var result strings.Builder
+
+	result.WriteString("PartitionCache Debug:\n")
+	result.WriteString("===================\n\n")
+
+	// Print partitions
+	result.WriteString("Partitions:\n")
+	if len(p.partitions) == 0 {
+		result.WriteString("  (none)\n")
+	} else {
+		for id, partition := range p.partitions {
+			result.WriteString(fmt.Sprintf("  ID: %d", id))
+			if !partition.Session.Empty() {
+				result.WriteString(fmt.Sprintf(" | Session: %s", partition.Session.ConnectionID.String()[:8]))
+			} else {
+				result.WriteString(" | Session: (unassigned)")
+			}
+			result.WriteString("\n")
+		}
+	}
+
+	// Print assignment index
+	result.WriteString("\nAssignment Index (session -> partitions):\n")
+	if len(p.assignmentIndex) == 0 {
+		result.WriteString("  (none)\n")
+	} else {
+		for session, partitions := range p.assignmentIndex {
+			result.WriteString(fmt.Sprintf("  %s: [", session.ConnectionID.String()[:8]))
+			partitionIDs := make([]int64, 0, len(partitions))
+			for id := range partitions {
+				partitionIDs = append(partitionIDs, id)
+			}
+			sort.Slice(partitionIDs, func(i, j int) bool {
+				return partitionIDs[i] < partitionIDs[j]
+			})
+			for i, id := range partitionIDs {
+				if i > 0 {
+					result.WriteString(", ")
+				}
+				result.WriteString(fmt.Sprintf("%d", id))
+			}
+			result.WriteString("]\n")
+		}
+	}
+
+	return result.String()
+}
+
+func (p *partitionCache) Init(partitions []Partition) {
+	p.partitions = make(map[int64]Partition)
+	p.assignmentIndex = make(map[Session]map[int64]struct{})
+
+	for _, partition := range partitions {
+		p.addPartition(partition)
+	}
+}
+
+func (p *partitionCache) Update(partitions map[int64]Partition) {
+	// TODO(queuefeed): When we introduce rangefeeds we probably need to add mvcc
+	// version to Partition to make sure updates from sql statements are kept
+	// coherent with updates from the rangefeed.
+	for id, newPartition := range partitions {
+		oldPartition := p.partitions[id]
+		switch {
+		case newPartition.Empty():
+			p.removePartition(id)
+		case oldPartition.Empty():
+			p.addPartition(newPartition)
+		default:
+			p.updatePartition(oldPartition, newPartition)
+		}
+	}
+}
+
+func (p *partitionCache) removePartition(partitionID int64) {
+	partition, exists := p.partitions[partitionID]
+	if !exists {
+		return
+	}
+
+	delete(p.partitions, partitionID)
+
+	// Remove from session index
+	if !partition.Session.Empty() {
+		if sessions, ok := p.assignmentIndex[partition.Session]; ok {
+			delete(sessions, partitionID)
+			if len(sessions) == 0 {
+				delete(p.assignmentIndex, partition.Session)
+			}
+		}
+	}
+}
+
+func (p *partitionCache) addPartition(partition Partition) {
+	// Add to main partition map
+	p.partitions[partition.ID] = partition
+
+	// Add to session index and partition index for assigned session
+	if !partition.Session.Empty() {
+		if _, ok := p.assignmentIndex[partition.Session]; !ok {
+			p.assignmentIndex[partition.Session] = make(map[int64]struct{})
+		}
+		p.assignmentIndex[partition.Session][partition.ID] = struct{}{}
+	}
+
+}
+
+func (p *partitionCache) updatePartition(oldPartition, newPartition Partition) {
+	// Update main partition map
+	p.partitions[newPartition.ID] = newPartition
+
+	// Remove old session assignments
+	if !oldPartition.Session.Empty() {
+		if sessions, ok := p.assignmentIndex[oldPartition.Session]; ok {
+			delete(sessions, oldPartition.ID)
+			if len(sessions) == 0 {
+				delete(p.assignmentIndex, oldPartition.Session)
+			}
+		}
+	}
+
+	// Add new session assignments
+	if !newPartition.Session.Empty() {
+		if _, ok := p.assignmentIndex[newPartition.Session]; !ok {
+			p.assignmentIndex[newPartition.Session] = make(map[int64]struct{})
+		}
+		p.assignmentIndex[newPartition.Session][newPartition.ID] = struct{}{}
+	}
+}
+
+func (p *partitionCache) isStale(assignment *Assignment) bool {
+	cachedAssignment := p.assignmentIndex[assignment.Session]
+	if len(assignment.Partitions) != len(cachedAssignment) {
+		return true
+	}
+	for _, partition := range assignment.Partitions {
+		if _, ok := cachedAssignment[partition.ID]; !ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *partitionCache) constructAssignment(session Session) *Assignment {
+	assignment := &Assignment{
+		Session:    session,
+		Partitions: make([]Partition, 0, len(p.assignmentIndex[session])),
+	}
+	for partitionID := range p.assignmentIndex[session] {
+		assignment.Partitions = append(assignment.Partitions, p.partitions[partitionID])
+	}
+	sort.Slice(assignment.Partitions, func(i, j int) bool {
+		return assignment.Partitions[i].ID < assignment.Partitions[j].ID
+	})
+	return assignment
+}
+
+func (p *partitionCache) planRegister(
+	session Session, cache partitionCache,
+) (tryClaim Partition, trySteal Partition) {
+	// Check to see if there is an an unassigned partition that can be claimed.
+	for _, partition := range cache.partitions {
+		if partition.Session.Empty() {
+			return partition, Partition{}
+		}
+	}
+	maxPartitions := (len(p.partitions) + len(p.assignmentIndex) - 1) / len(p.assignmentIndex)
+	return Partition{}, p.planTheft(1, maxPartitions)
+}
+
+func (p *partitionCache) planAssignment(
+	session Session, caughtUp bool, cache partitionCache,
+) (tryRelease []Partition, tryClaim Partition, trySteal Partition) {
+
+	for partitionId := range p.assignmentIndex[session] {
+		partition := p.partitions[partitionId]
+		if !partition.Successor.Empty() {
+			tryRelease = append(tryRelease, partition)
+		}
+	}
+	if len(tryRelease) != 0 {
+		return tryRelease, Partition{}, Partition{}
+	}
+
+	// If we aren't caught up, we should not try to claim any new partitions.
+	if !caughtUp {
+		return nil, Partition{}, Partition{}
+	}
+
+	// Check to see if there is an an unassigned partition that can be claimed.
+	for _, partition := range p.partitions {
+		// TODO(jeffswenson): we should really try to claim a random partition to
+		// avoid contention.
+		if partition.Session.Empty() {
+			return nil, partition, Partition{}
+		}
+	}
+
+	// maxPartitions is the maximum number of partitions we would expect to be
+	// assigned to this session.
+	maxPartitions := len(p.partitions)
+	if len(p.assignmentIndex) != 0 {
+		maxPartitions = (len(p.partitions) + len(p.assignmentIndex) - 1) / len(p.assignmentIndex)
+	}
+	assignedPartitions := len(p.assignmentIndex[session])
+	if maxPartitions <= assignedPartitions {
+		return nil, Partition{}, Partition{}
+	}
+
+	// NOTE: planTheft may return an empty partition. E.g. consider the case
+	// where there are two sessions and three partitions. In that case the
+	// maximum partition assignment is 2, but one partition will end up with
+	// only 1 assignment. It will consider stealing even though the partitions
+	// are balanced.
+	//
+	// We prioritize stealing sessions from any client that has more than the
+	// maximum expected number of partitions. But we are willing to steal from
+	// any client that has two more partitions than this client currently has.
+	// Stealing from someone with less than the maximum expected number of is
+	// needed to handle distributions like:
+	// a -> 3 partitions
+	// b -> 3 partitions
+	// c -> 1 partition
+	return nil, Partition{}, p.planTheft(assignedPartitions+1, maxPartitions)
+}
+
+// planTheft selects a partition from a session that has more partitions
+// assigned to it than the richTreshold. E.g. `richTreshold` is 1, any session
+// with 2 or more partitions is a candidate for work stealing.
+func (p *partitionCache) planTheft(minumExpected, maximumExpected int) Partition {
+	richCandidates, eligibleCandidates := []Partition{}, []Partition{}
+	for _, session := range p.assignmentIndex {
+		assignedPartitions := len(session)
+		if maximumExpected < assignedPartitions {
+			for partitionID := range session {
+				richCandidates = append(richCandidates, p.partitions[partitionID])
+			}
+		}
+		if minumExpected < assignedPartitions {
+			for partitionID := range session {
+				eligibleCandidates = append(eligibleCandidates, p.partitions[partitionID])
+			}
+		}
+	}
+
+	if len(richCandidates) != 0 {
+		return richCandidates[rand.Intn(len(richCandidates))]
+	}
+	if len(eligibleCandidates) != 0 {
+		return eligibleCandidates[rand.Intn(len(eligibleCandidates))]
+	}
+	return Partition{}
+}

--- a/pkg/sql/queuefeed/partition_cache_test.go
+++ b/pkg/sql/queuefeed/partition_cache_test.go
@@ -1,0 +1,211 @@
+package queuefeed
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+type assignmentSimulator struct {
+	t        *testing.T
+	sessions []Session
+	cache    partitionCache
+}
+
+func newAssignmentSimulator(t *testing.T, partitionCount int) *assignmentSimulator {
+	partitions := make([]Partition, partitionCount)
+	for i := range partitions {
+		partitions[i] = Partition{
+			ID:        int64(i + 1),
+			Session:   Session{}, // Unassigned
+			Successor: Session{},
+		}
+	}
+	sim := &assignmentSimulator{t: t}
+	sim.cache.Init(partitions)
+	return sim
+}
+
+// refreshAssignment returns true if refreshing the assignment took any action.
+func (a *assignmentSimulator) refreshAssignment(session Session) bool {
+	tryRelease, tryClaim, trySecede := a.cache.planAssignment(session, true, a.cache)
+
+	updates := make(map[int64]Partition)
+
+	// This is simulating the production implementation. The prod implementation
+	// would use a txn to apply these changes to the DB, then update the cache
+	// with the latest version of the rows.
+	for _, partition := range tryRelease {
+		updates[partition.ID] = Partition{
+			ID:        partition.ID,
+			Session:   partition.Successor,
+			Successor: Session{},
+			Span:      partition.Span,
+		}
+	}
+	if !tryClaim.Empty() {
+		updates[tryClaim.ID] = Partition{
+			ID:        tryClaim.ID,
+			Session:   session,
+			Successor: Session{},
+			Span:      tryClaim.Span,
+		}
+	}
+	if !trySecede.Empty() {
+		updates[trySecede.ID] = Partition{
+			ID:        trySecede.ID,
+			Session:   trySecede.Session,
+			Successor: session,
+			Span:      trySecede.Span,
+		}
+	}
+
+	a.cache.Update(updates)
+
+	return len(updates) != 0
+}
+
+func (a *assignmentSimulator) createSession() Session {
+	session := Session{
+		ConnectionID: uuid.MakeV4(),
+		LivenessID:   sqlliveness.SessionID(uuid.MakeV4().String()),
+	}
+
+	a.sessions = append(a.sessions, session)
+
+	// This is simulating the production implementation. The prod implementation
+	// would use a txn to apply these changes to the DB, then update the cache
+	// with the latest version of the rows.
+	tryClaim, trySecede := a.cache.planRegister(session, a.cache)
+
+	updates := make(map[int64]Partition)
+	if !tryClaim.Empty() {
+		tryClaim.Session = session
+		updates[tryClaim.ID] = tryClaim
+	}
+	if !trySecede.Empty() {
+		trySecede.Successor = session
+		updates[trySecede.ID] = trySecede
+	}
+	a.cache.Update(updates)
+
+	return session
+}
+
+func (a *assignmentSimulator) removeSession(session Session) {
+	// Remove session from sessions list
+	for i, s := range a.sessions {
+		if s == session {
+			a.sessions = append(a.sessions[:i], a.sessions[i+1:]...)
+			break
+		}
+	}
+
+	assignment := a.cache.constructAssignment(session)
+	updates := make(map[int64]Partition)
+
+	for _, partition := range assignment.Partitions {
+		// For each partition assigned to this session, make the successor (if any)
+		// the owner.
+		updates[partition.ID] = Partition{
+			ID:        partition.ID,
+			Session:   partition.Successor,
+			Successor: Session{}, // Clear successor
+			Span:      partition.Span,
+		}
+	}
+	// Any partitions where this session is the successor should have
+	// the successor cleared.
+	for id := range a.cache.partitions {
+		if a.cache.partitions[id].Successor != session {
+			continue
+		}
+		partition := a.cache.partitions[id]
+		updates[partition.ID] = Partition{
+			ID:        partition.ID,
+			Session:   partition.Session, // Keep current owner
+			Successor: Session{},         // Clear successor
+			Span:      partition.Span,
+		}
+	}
+
+	a.cache.Update(updates)
+}
+
+func (a *assignmentSimulator) runToStable() {
+	maxIterations := 100000 // Prevent infinite loops
+
+	for i := 0; i < maxIterations; i++ {
+		actionTaken := false
+
+		// Process each session
+		for _, session := range a.sessions {
+			if a.refreshAssignment(session) {
+				actionTaken = true
+			}
+		}
+
+		// If no action was taken in this round, we're stable
+		if !actionTaken {
+			return
+		}
+	}
+
+	a.t.Fatalf("runToStable exceeded maximum iterations (%d sessions, %d partitions): %s ", len(a.sessions), len(a.cache.partitions), a.cache.DebugString())
+}
+
+func TestPartitionCacheSimple(t *testing.T) {
+	sim := newAssignmentSimulator(t, 2)
+
+	// Create two sessions.
+	session1 := sim.createSession()
+	sim.runToStable()
+	session2 := sim.createSession()
+	sim.runToStable()
+
+	// Each session should have one partition.
+	assignment1 := sim.cache.constructAssignment(session1)
+	assignment2 := sim.cache.constructAssignment(session2)
+	require.Len(t, assignment1.Partitions, 1)
+	require.Len(t, assignment2.Partitions, 1)
+
+	// After removing one session, the other session should have both partitions.
+	sim.removeSession(session1)
+	sim.runToStable()
+	assignment2 = sim.cache.constructAssignment(session2)
+	require.Len(t, assignment2.Partitions, 2)
+}
+
+func TestPartitionCacheRandom(t *testing.T) {
+	partitions := rand.Intn(1000) + 1
+	sessions := make([]Session, rand.Intn(100)+1)
+
+	sim := newAssignmentSimulator(t, partitions)
+
+	for i := range sessions {
+		if rand.Int()%2 == 0 {
+			sim.runToStable()
+		}
+		sessions[i] = sim.createSession()
+	}
+	sim.runToStable()
+
+	t.Logf("%d partitions, %d sessions", partitions, len(sessions))
+	t.Log(sim.cache.DebugString())
+
+	// Verify all partitions are assigned
+	for _, partition := range sim.cache.partitions {
+		require.False(t, partition.Session.Empty())
+	}
+
+	// Verify that no session has more than ceil(partitions / len(sessions))
+	// partitions.
+	maxPerSession := (partitions + len(sessions) - 1) / len(sessions)
+	for _, session := range sessions {
+		assignment := sim.cache.constructAssignment(session)
+		require.LessOrEqual(t, len(assignment.Partitions), maxPerSession)
+	}
+}

--- a/pkg/sql/queuefeed/partitions.go
+++ b/pkg/sql/queuefeed/partitions.go
@@ -171,7 +171,7 @@ type Session struct {
 	LivenessID sqlliveness.SessionID
 }
 
-func (s *Session) Empty() bool {
+func (s Session) Empty() bool {
 	return s.ConnectionID == uuid.Nil && s.LivenessID == ""
 }
 


### PR DESCRIPTION
This change includes the partition cache. The idea is this will be refreshed based on the rangefeed and local transactions that update the table. The core assignment algorithms were implemented against the cache which allows us to quickly test a large number of random scenarios.

The production assigner will basically mimic the simulation assigner, but it will use txns to update rows in the db before applying the updates to the cache.